### PR TITLE
Security review report + basic hardening (fixes #3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,7 @@ MAX_TOKENS=800
 
 # Server
 PORT=5174
+HOST=127.0.0.1
 DATA_DIR=./projects
 WORKSPACE_DIR=./.workspace
+CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ cp .env.example .env
 Notes:
 - `.env` is gitignored (do not commit secrets).
 - `OPENAI_API_KEY` is required when `MODEL` points to an OpenAI model (for the agent features).
+- `HOST` controls where the API server binds (default `127.0.0.1`).
+- `CORS_ORIGINS` is a comma-separated allowlist for the web UI origin(s) (use `*` to allow all origins).
 
 ### Running Tests
 

--- a/docs/security-review-2026-04-24.md
+++ b/docs/security-review-2026-04-24.md
@@ -1,0 +1,40 @@
+# Security review (Issue #3)
+
+Date: 2026-04-24  
+Scope: `packages/server`, `packages/web`, `packages/shared`, local filesystem project storage under `./projects/<projectId>/`
+
+This codebase looks like an MVP intended for **local** use. There is **no authentication** and the server reads/writes content on disk, so treating it as an internet-exposed service would be unsafe without additional controls (reverse proxy auth, network restrictions, rate limiting, etc.).
+
+## Key findings
+
+### 1) Unauthenticated API + permissive CORS + broad bind defaults (HIGH)
+**Impact:** If the server is reachable from a browser outside the local machine (e.g., bound to `0.0.0.0`, port-forwarded, or deployed), a malicious website could drive API calls from a victim’s browser and modify projects (or spam the agent endpoints).  
+**Notes:** Prior configuration used `cors()` default (allow all origins) and `app.listen(PORT)` default host binding.
+
+**Mitigation implemented in this PR:**
+- Added `HOST` (default `127.0.0.1`) and `CORS_ORIGINS` allowlist (default `http://localhost:5173,http://127.0.0.1:5173`) in `packages/server/src/config.ts`.
+- Updated CORS setup to only emit CORS headers for allowed origins.
+
+**Further recommendations:**
+- Add authentication (even simple token) for any non-local deployment.
+- Add rate limiting / request throttling for `/api/projects/:id/agent/*` endpoints.
+- Run behind a reverse proxy with IP allowlist and request size/time limits.
+
+### 2) Path traversal / arbitrary file write via weak id validation (HIGH)
+**Impact:** `AssetIdSchema` previously allowed arbitrary strings. Because `PUT /api/projects/:projectId/page` accepts client-controlled `assets[]`, an attacker could store an asset with an id containing path separators and then use `POST /assets/images/:assetId/replace` to write outside of `assets/` (path traversal via `path.join(assetsDir, filename)`).
+
+**Mitigation implemented in this PR:**
+- Tightened `AssetIdSchema`, `SectionIdSchema`, `ComponentIdSchema` to safe `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$` in `packages/shared/src/page-schema.ts`.
+- `replace` endpoint now parses `assetId` using `AssetIdSchema`.
+
+### 3) Static exposure of project files (MEDIUM)
+**Impact:** `app.use("/projects", express.static(dataDirAbs))` makes project content accessible over HTTP. That includes `page.json`, `output/`, and `.workspace/` artifacts (e.g. screenshots), which may contain sensitive content depending on how the tool is used.  
+**Recommendation:** In production, serve only the exported site output, or gate `/projects` behind auth; consider disabling `.workspace` exposure.
+
+### 4) Dependency / supply-chain risks (MEDIUM)
+**Impact:** Standard Node.js ecosystem risk; without a CI audit policy, vulnerable transitive dependencies can land unnoticed.  
+**Recommendation:** Add CI job for `pnpm audit` (or OSV-based scanning) and a Renovate/Dependabot policy.
+
+## Notes on frontend XSS
+`packages/web/src/ui/app.tsx` uses `dangerouslySetInnerHTML` for rich text, but it sanitizes user HTML (allowed tags + safe `href` protocol filter, strips attributes). That’s a reasonable approach for this MVP, but consider adding a CSP when serving the exported page on the web.
+

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -2,8 +2,10 @@ import { z } from "zod";
 
 const EnvSchema = z.object({
   PORT: z.coerce.number().int().positive().default(5174),
+  HOST: z.string().default("127.0.0.1"),
   DATA_DIR: z.string().default("./projects"),
   WORKSPACE_DIR: z.string().default("./.workspace"),
+  CORS_ORIGINS: z.string().default("http://localhost:5173,http://127.0.0.1:5173"),
 });
 
 export type ServerConfig = z.infer<typeof EnvSchema>;
@@ -11,4 +13,3 @@ export type ServerConfig = z.infer<typeof EnvSchema>;
 export function loadConfig(env: Record<string, string | undefined>): ServerConfig {
   return EnvSchema.parse(env);
 }
-

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -22,7 +22,23 @@ const dataDirAbs = path.resolve(projectRoot, config.DATA_DIR);
 const store = new ProjectStore(dataDirAbs);
 const app = express();
 
-app.use(cors({ exposedHeaders: ["ETag"] }));
+const allowedOrigins = new Set(
+  config.CORS_ORIGINS.split(",")
+    .map((v) => v.trim())
+    .filter(Boolean)
+);
+
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin) return callback(null, true);
+      if (allowedOrigins.has("*")) return callback(null, true);
+      if (allowedOrigins.has(origin)) return callback(null, true);
+      return callback(null, false);
+    },
+    exposedHeaders: ["ETag"],
+  })
+);
 app.use(express.json({ limit: "5mb" }));
 
 const ProjectIdSchema = z
@@ -102,6 +118,6 @@ app.use("/api/projects/:projectId/preview", createPreviewRouter({ store, project
 
 app.use("/projects", express.static(dataDirAbs, { fallthrough: true }));
 
-app.listen(config.PORT, () => {
-  console.log(`[server] listening on http://localhost:${config.PORT}`);
+app.listen(config.PORT, config.HOST, () => {
+  console.log(`[server] listening on http://${config.HOST}:${config.PORT}`);
 });

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -4,7 +4,7 @@ import express from "express";
 import multer from "multer";
 import { z, type ZodType } from "zod";
 import imageSize from "image-size";
-import { ImageAssetSchema } from "@cac/shared";
+import { AssetIdSchema, ImageAssetSchema } from "@cac/shared";
 import type { ProjectStore } from "../project-store.js";
 
 interface CreateAssetRouterOptions {
@@ -76,7 +76,7 @@ export function createAssetRouter(options: CreateAssetRouterOptions): express.Ro
 
   router.post("/images/:assetId/replace", upload.single("file"), async (req, res) => {
     const projectId = projectIdSchema.parse((req.params as { projectId?: string }).projectId);
-    const assetId = z.string().min(1).parse((req.params as { assetId?: string }).assetId);
+    const assetId = AssetIdSchema.parse((req.params as { assetId?: string }).assetId);
     const clientEtag = z.string().min(1).optional().parse(req.header("if-match"));
 
     const file = req.file;

--- a/packages/shared/src/page-schema.ts
+++ b/packages/shared/src/page-schema.ts
@@ -1,8 +1,13 @@
 import { z } from "zod";
 
-export const AssetIdSchema = z.string().min(1);
-export const ComponentIdSchema = z.string().min(1);
-export const SectionIdSchema = z.string().min(1);
+const IdSchema = z
+  .string()
+  .min(1)
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/, "Invalid id format");
+
+export const AssetIdSchema = IdSchema;
+export const ComponentIdSchema = IdSchema;
+export const SectionIdSchema = IdSchema;
 
 export const PageMetadataSchema = z.object({
   title: z.string().min(1).default("Untitled Page"),

--- a/packages/web/src/ui/app.tsx
+++ b/packages/web/src/ui/app.tsx
@@ -1862,7 +1862,7 @@ export function App() {
                               {imageAssets.map((asset) => (
                                 <div key={asset.id} className="row" style={{ alignItems: "flex-start" }}>
                                   <img
-                                    src={`/projects/${encodeURIComponent(activeProjectId)}/assets/${asset.filename}`}
+                                    src={`/projects/${encodeURIComponent(activeProjectId)}/assets/${encodeURIComponent(asset.filename)}`}
                                     alt={asset.alt}
                                     style={{
                                       width: 44,
@@ -2653,7 +2653,7 @@ function PreviewComponent(props: {
         <div className="imageBlock" style={{ ...blockStyle, pointerEvents: isSelected ? "auto" : "none" }}>
           <div className="imageMedia">
             <img
-              src={`/projects/${encodeURIComponent(projectId)}/assets/${asset.filename}`}
+              src={`/projects/${encodeURIComponent(projectId)}/assets/${encodeURIComponent(asset.filename)}`}
               alt={asset.alt}
               style={imgStyle}
               onClick={(e) => {


### PR DESCRIPTION
Closes #3.

- Adds security review report: docs/security-review-2026-04-24.md
- Hardens ID validation to prevent path traversal via crafted asset IDs
- Adds safer server defaults: HOST (127.0.0.1) + CORS_ORIGINS allowlist
- Encodes asset filenames in web UI asset URLs